### PR TITLE
Guard headline outline containers for older Org

### DIFF
--- a/ox-twbs.el
+++ b/ox-twbs.el
@@ -44,6 +44,7 @@
 (require 'format-spec)
 (eval-when-compile (require 'cl) (require 'table nil 'noerror))
 
+(declare-function org-export-solidify-link-text "ox" (s))
 
 ;;; Function Declarations
 
@@ -2747,10 +2748,35 @@ channel."
              (let ((scheduled (org-element-property :scheduled planning)))
                (when scheduled
                  (format span-fmt org-scheduled-string
-                         (org-timestamp-translate scheduled))))))
-      " "))))
+(defun org-twbs--solidify-link-text (text)
+  "Return a sanitized identifier for TEXT.
+Use Org's `org-export-solidify-link-text' when available, otherwise
+fallback to a minimal replacement that preserves ASCII word characters."
+  (when (stringp text)
+    (if (fboundp 'org-export-solidify-link-text)
+        (org-export-solidify-link-text text)
+      (replace-regexp-in-string "[^A-Za-z0-9_:-]" "-" text))))
 
-;;;; Property Drawer
+(defun org-twbs--headline-section-id (headline info)
+  "Return identifier for HEADLINE's outline text container.
+INFO is the export state plist.  Fall back gracefully when older Org
+versions omit section elements so the exporter keeps working."
+  (or (org-element-property :CUSTOM_ID headline)
+      (let ((headline-number
+             (when (fboundp 'org-export-get-headline-number)
+               (with-no-warnings
+                 (condition-case nil
+                     (org-export-get-headline-number headline info)
+                   (wrong-number-of-arguments
+                    (org-export-get-headline-number headline)))))))
+        (and headline-number
+             (mapconcat #'number-to-string headline-number "-")))
+      (org-twbs--solidify-link-text (org-element-property :ID headline))
+      (org-twbs--solidify-link-text (org-element-property :name headline))
+      ""))
+
+         (section-id (org-twbs--headline-section-id headline info)))
+            section-id
 
 (defun org-twbs-property-drawer (property-drawer contents info)
   "Transcode a PROPERTY-DRAWER element from Org to HTML.

--- a/test/ox-twbs-test.el
+++ b/test/ox-twbs-test.el
@@ -38,6 +38,11 @@ HTML produced by `org-export-string-as' using the twbs back-end."
       (should grandchild-pos)
       (should (< text-pos grandchild-pos)))))
 
+(ert-deftest org-twbs-export-uses-custom-ids-for-outline-text ()
+  "Custom IDs should drive outline text container identifiers."
+  (org-twbs-test-with-export "* Parent\n:PROPERTIES:\n:CUSTOM_ID: parent-id\n:END:\n** Child\n"
+    (should (string-match "<div class=\\\"outline-text-1\\\" id=\\\"text-parent-id\\\">" output))))
+
 (provide 'ox-twbs-test)
 
 ;;; ox-twbs-test.el ends here


### PR DESCRIPTION
## Summary
- add helpers that sanitise outline text IDs and tolerate Org builds that omit section nodes
- ensure outline-text wrappers derive stable identifiers from CUSTOM_ID, headline numbers, or other metadata
- extend the ERT suite with a regression test that confirms CUSTOM_ID drives the generated outline container id

## Testing
- not run (emacs binary is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e77fb187e48327883c754e324f6792